### PR TITLE
Add friendly id gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'sass-rails', '~> 5.0'
 gem 'uglifier', '>= 1.3.0'
 gem 'turbolinks', '~> 5'
 gem 'devise', '~> 4.3.0'
+gem 'friendly_id', '~> 5.1.0'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,8 @@ GEM
     erubi (1.6.0)
     execjs (2.7.0)
     ffi (1.9.18)
+    friendly_id (5.1.0)
+      activerecord (>= 4.0.0)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
     i18n (0.8.1)
@@ -156,6 +158,7 @@ PLATFORMS
 DEPENDENCIES
   byebug
   devise (~> 4.3.0)
+  friendly_id (~> 5.1.0)
   listen (>= 3.0.5, < 3.2)
   pg (~> 0.18)
   puma (~> 3.7)

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -22,6 +22,8 @@ class PostsController < ApplicationController
   end
 
   def update
+    @post.slug = nil
+
     if @post.update(post_params)
       redirect_to @post
     else
@@ -39,12 +41,12 @@ class PostsController < ApplicationController
 
   private
 
-    def set_post
-        @post = Post.find(params[:id])
-    end
+  def set_post
+    @post = Post.friendly.find(params[:id])
+  end
 
-    def post_params
-        params.require(:post).permit([:title, :slug, :body, :lead])
-    end
+  def post_params
+    params.require(:post).permit([:title, :slug, :body, :lead])
+  end
 
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,2 +1,5 @@
 class Post < ApplicationRecord
+  extend FriendlyId
+
+  friendly_id :title, use: :slugged
 end

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -10,11 +10,6 @@
   </div>
 
   <div class="field">
-    <%= form.label :slug %>
-    <%= form.text_field :slug, id: :post_slug %>
-  </div>
-
-  <div class="field">
     <%= form.label :lead %>
     <%= form.text_field :lead, id: :post_lead %>
   </div>

--- a/config/initializers/friendly_id.rb
+++ b/config/initializers/friendly_id.rb
@@ -1,0 +1,6 @@
+FriendlyId.defaults do |config|
+  config.use :reserved
+
+  config.reserved_words = %w(new edit index session login logout users admin
+    stylesheets assets javascripts images)
+end

--- a/db/migrate/20170520024651_create_friendly_id_slugs.rb
+++ b/db/migrate/20170520024651_create_friendly_id_slugs.rb
@@ -1,0 +1,15 @@
+class CreateFriendlyIdSlugs < ActiveRecord::Migration[5.1]
+  def change
+    create_table :friendly_id_slugs do |t|
+      t.string   :slug,           :null => false
+      t.integer  :sluggable_id,   :null => false
+      t.string   :sluggable_type, :limit => 50
+      t.string   :scope
+      t.datetime :created_at
+    end
+    add_index :friendly_id_slugs, :sluggable_id
+    add_index :friendly_id_slugs, [:slug, :sluggable_type]
+    add_index :friendly_id_slugs, [:slug, :sluggable_type, :scope], :unique => true
+    add_index :friendly_id_slugs, :sluggable_type
+  end
+end

--- a/db/migrate/20170520025818_add_unique_index_to_posts.rb
+++ b/db/migrate/20170520025818_add_unique_index_to_posts.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToPosts < ActiveRecord::Migration[5.1]
+  def change
+    add_index :posts, :slug, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,31 @@
-ActiveRecord::Schema.define(version: 20170520001943) do
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 20170520025818) do
+
+  # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "friendly_id_slugs", force: :cascade do |t|
+    t.string "slug", null: false
+    t.integer "sluggable_id", null: false
+    t.string "sluggable_type", limit: 50
+    t.string "scope"
+    t.datetime "created_at"
+    t.index ["slug", "sluggable_type", "scope"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope", unique: true
+    t.index ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type"
+    t.index ["sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_id"
+    t.index ["sluggable_type"], name: "index_friendly_id_slugs_on_sluggable_type"
+  end
 
   create_table "posts", force: :cascade do |t|
     t.string "title"
@@ -9,9 +35,8 @@ ActiveRecord::Schema.define(version: 20170520001943) do
     t.datetime "published_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["slug"], name: "index_posts_on_slug", unique: true
   end
-
-  enable_extension "plpgsql"
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false


### PR DESCRIPTION
- This PR will allow us to auto-generate slugs for our posts;
- The `@post.slug = nil` statement is needed because [the gem doesn't regenerate the slugs anymore](https://github.com/norman/friendly_id#what-changed-in-version-50)