### PR TITLE
Update dashboard to create post

### DIFF
--- a/app/controllers/dashboard/posts_controller.rb
+++ b/app/controllers/dashboard/posts_controller.rb
@@ -1,5 +1,5 @@
 class Dashboard::PostsController < ApplicationController
-  before_action :set_post, only:[:show, :update, :destroy, :edit]
+  before_action :set_post, only: [:show, :update, :destroy, :edit]
   before_action :authenticate_dashboard_user!
 
   def index
@@ -10,7 +10,7 @@ class Dashboard::PostsController < ApplicationController
     @post = Post.new(post_params)
 
     if @post.save
-      redirect_to @post
+      redirect_to dashboard_post_path(@post)
     else
       render :new
     end
@@ -26,7 +26,7 @@ class Dashboard::PostsController < ApplicationController
     @post.slug = nil
 
     if @post.update(post_params)
-      redirect_to @post
+      redirect_to dashboard_post_path(@post)
     else
       render :edit
     end
@@ -47,6 +47,6 @@ class Dashboard::PostsController < ApplicationController
   end
 
   def post_params
-    params.require(:post).permit([:title, :slug, :body, :lead, :status])
+    params.require(:post).permit([:title, :body, :lead, :status])
   end
 end

--- a/app/views/dashboard/panel/index.html.erb
+++ b/app/views/dashboard/panel/index.html.erb
@@ -3,3 +3,5 @@ dashboard
 <%= link_to('Posts', dashboard_posts_path) %>
 
 <%= link_to('Change profile picture', '/dashboard/picture')%>
+
+<%= link_to('Criar post', dashboard_post_path(:new)) %>

--- a/app/views/dashboard/posts/_form.html.erb
+++ b/app/views/dashboard/posts/_form.html.erb
@@ -1,17 +1,17 @@
-<%= form_with(model: post, local: true) do |form| %>
+<%= form_with(model: [:dashboard, post], local: true) do |form| %>
   <div class="field">
     <%= form.label :title %>
     <%= form.text_field :title, id: :post_title %>
   </div>
 
   <div class="field">
-    <%= form.label :body %>
-    <%= form.text_field :body, id: :post_body %>
+    <%= form.label :lead %>
+    <%= form.text_field :lead, id: :post_lead %>
   </div>
 
   <div class="field">
-    <%= form.label :lead %>
-    <%= form.text_field :lead, id: :post_lead %>
+    <%= form.label :body %>
+    <%= form.text_area :body, id: :post_body %>
   </div>
 
   <div class="actions">

--- a/app/views/dashboard/posts/index.html.erb
+++ b/app/views/dashboard/posts/index.html.erb
@@ -13,6 +13,9 @@
     <% @posts.each do |post| %>
       <tr>
         <td><%= post.title %></td>
+        <td><%= post.slug %></td>
+        <td><%= post.lead %></td>
+        <td><%= post.status %></td>
         <td><%= post.published_at %></td>
         <td><%= link_to 'edit', edit_dashboard_post_path(post) %></td>
       </tr>


### PR DESCRIPTION
The posts view on the dashboard was broken due to the change of the namespace.

This is an update with the routes to create and edit a post fully working. Also, add a link to create a post on the dashboard that was missing.